### PR TITLE
CloudWatch Logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+default: test
+
+test:
+	go test . -short
+
+integration:
+	go test . -v

--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,114 @@
+package cloudwatch
+
+import (
+	"log"
+	"time"
+)
+
+func batch(logs <-chan Log, capacity Capacity) <-chan []Log {
+	batches := make(chan []Log)
+	batcher := NewBatcher(logs, batches, capacity)
+
+	go func() {
+		defer close(batches)
+		batcher.Start()
+	}()
+
+	return batches
+}
+
+// Batcher buffers messages on a channel until a flush is triggered.
+type Batcher struct {
+	in  <-chan Log
+	out chan<- []Log
+
+	messages []Log
+	capacity Capacity
+	timer    <-chan time.Time
+	size     int
+}
+
+// NewBatcher creates a Batcher that buffers message from the input channel to the
+// output channel.
+func NewBatcher(in <-chan Log, out chan<- []Log, capacity Capacity) *Batcher {
+	return &Batcher{in: in, out: out, capacity: capacity}
+}
+
+// Length returns the current length of the buffer.
+func (b *Batcher) Length() int {
+	return len(b.messages)
+}
+
+// Start begins buffering messages from the input channel.
+func (b *Batcher) Start() {
+loop:
+	for {
+		select {
+		case l, ok := <-b.in:
+			if !ok {
+				break loop
+			}
+
+			if b.willOverflow(l) {
+				log.Printf("Batch flushed to prevent size overflow - size: %d, capacity: %v", b.size, b.capacity)
+				b.flush()
+			}
+
+			b.messages = append(b.messages, l)
+			b.size += l.Size()
+
+			if b.isFullSize() {
+				log.Printf("Batch flushed due to batch size - size: %d, capacity: %v", b.size, b.capacity)
+				b.flush()
+			} else if b.isFullLength() {
+				log.Printf("Batch flushed due to batch length - length: %d, capacity: %v", len(b.messages), b.capacity)
+				b.flush()
+			} else {
+				b.startFlushTimer()
+			}
+		case <-b.timer:
+			log.Printf("Batch flushed due to timer - capacity: %v", b.capacity)
+			b.flush()
+		}
+	}
+
+	b.flush()
+}
+
+func (b *Batcher) willOverflow(log Log) bool {
+	return b.size+log.Size() > b.capacity.Size
+}
+
+func (b *Batcher) isFullSize() bool {
+	return b.size >= b.capacity.Size
+}
+
+func (b *Batcher) isFullLength() bool {
+	return len(b.messages) == b.capacity.Length
+}
+
+func (b *Batcher) flush() {
+	messages := make([]Log, len(b.messages))
+	copy(messages, b.messages)
+
+	b.timer = nil
+	b.messages = nil
+	b.size = 0
+
+	if len(messages) != 0 {
+		b.out <- messages
+	}
+}
+
+func (b *Batcher) startFlushTimer() {
+	if b.timer == nil && b.capacity.Duration > 0 {
+		b.timer = time.After(b.capacity.Duration)
+	}
+}
+
+// Capacity returns conditions that trigger a Batcher to flush.
+type Capacity struct {
+	Size     int
+	Length   int
+	Duration time.Duration
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,113 @@
+package cloudwatch
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestBatch(t *testing.T) {
+	TestingT(t)
+}
+
+type BatchSuite struct {
+	in  chan Log
+	out chan []Log
+}
+
+var _ = Suite(&BatchSuite{})
+
+func (s *BatchSuite) SetUpTest(c *C) {
+	s.in = make(chan Log)
+	s.out = make(chan []Log)
+}
+
+// TODO: Test closing channel.
+
+func (s *BatchSuite) TestBatcherWhenNotFull(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 2, Size: 2})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 0}
+
+	c.Assert(batcher.Length(), Equals, 1)
+}
+
+func (s *BatchSuite) TestFlushWhenCountReached(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 2, Size: 4})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 1}
+	s.in <- &FakeLog{size: 1}
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 2)
+	c.Assert(batcher.Length(), Equals, 0)
+}
+
+func (s *BatchSuite) TestFlushWhenSizeReached(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 4, Size: 2})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 1}
+	s.in <- &FakeLog{size: 1}
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 2)
+	c.Assert(batcher.Length(), Equals, 0)
+}
+
+func (s *BatchSuite) TestFlushWhenSizeExceeded(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 4, Size: 3})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 2}
+	s.in <- &FakeLog{size: 2}
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 1)
+	c.Assert(batcher.Length(), Equals, 1)
+}
+
+func (s *BatchSuite) TestFlushOversizedMessage(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 4, Size: 1})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 2}
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 1)
+	c.Assert(batcher.Length(), Equals, 0)
+}
+
+func (s *BatchSuite) TestFlushWhenDurationExceeded(c *C) {
+	duration := 1 * time.Millisecond
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 2, Size: 2, Duration: duration})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 1}
+	time.Sleep(2 * time.Millisecond)
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 1)
+	c.Assert(batcher.Length(), Equals, 0)
+}
+
+func (s *BatchSuite) TestFlushWhenClosed(c *C) {
+	batcher := NewBatcher(s.in, s.out, Capacity{Length: 2, Size: 2})
+	go batcher.Start()
+
+	s.in <- &FakeLog{size: 0}
+	close(s.in)
+
+	messages := <-s.out
+
+	c.Assert(messages, HasLen, 1)
+	c.Assert(batcher.Length(), Equals, 0)
+}

--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -1,0 +1,70 @@
+package cloudwatch
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/gliderlabs/logspout/router"
+)
+
+// Set batch sizes based CloudWatch Logs limits found in the developer guide.
+// While the actual size limit is 1 MB, we use 900 KB due to small differences
+// in how batch size is calculated.
+const batchSize = 900000
+const batchLength = 10000
+const batchDuration = 250 * time.Millisecond
+
+func init() {
+	router.AdapterFactories.Register(NewAdapter, "cloudwatch")
+}
+
+// Adapter ships logs to AWS CloudWatch.
+type Adapter struct {
+	route     *router.Route
+	logstream *LogStream
+	capacity  Capacity
+}
+
+// NewAdapter instances a new AWS CloudWatch adapter.
+func NewAdapter(route *router.Route) (router.LogAdapter, error) {
+	group := os.Getenv("AWS_LOG_GROUP")
+	stream := os.Getenv("AWS_LOG_STREAM")
+	logstream, err := NewLogStream(group, stream)
+	if err != nil {
+		return nil, err
+	}
+
+	capacity := Capacity{
+		Size:     batchSize,
+		Length:   batchLength,
+		Duration: batchDuration,
+	}
+
+	log.Printf("Created CloudWatch adapter - group: %s, stream: %s", group, stream)
+
+	return &Adapter{route: route, logstream: logstream, capacity: capacity}, nil
+}
+
+// Stream passes messages from a logspout message channel to AWS CloudWatch.
+func (a *Adapter) Stream(logstream chan *router.Message) {
+	log.Printf("CloudWatch adapter is streaming Docker logs")
+
+	logs := transform(logstream)
+	batches := batch(logs, a.capacity)
+
+	for batch := range batches {
+		events := make([]*cloudwatchlogs.InputLogEvent, len(batch))
+
+		for i, log := range batch {
+			events[i] = &cloudwatchlogs.InputLogEvent{
+				Message:   aws.String(log.Body()),
+				Timestamp: aws.Int64(log.Timestamp()),
+			}
+		}
+
+		a.logstream.Log(events)
+	}
+}

--- a/cloudwatch_test.go
+++ b/cloudwatch_test.go
@@ -1,0 +1,57 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Pallinder/go-randomdata"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/gliderlabs/logspout/router"
+)
+
+const NumMessages = 2000000
+
+func generateBatch(size int) []*cloudwatchlogs.InputLogEvent {
+	batch := make([]*cloudwatchlogs.InputLogEvent, size)
+
+	for i := 0; i < size; i++ {
+		msg := randomdata.Paragraph()
+		json := fmt.Sprintf("{ \"message\": \"%s\", \"category\": \"logspout\" }", msg)
+		now := time.Now().Unix() * 1000
+
+		batch[i] = &cloudwatchlogs.InputLogEvent{
+			Message:   aws.String(json),
+			Timestamp: aws.Int64(now),
+		}
+	}
+
+	return batch
+}
+
+func TestCloudWatchAdapter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode.")
+	}
+
+	os.Setenv("AWS_LOG_GROUP", "logspout-cloudwatch")
+	os.Setenv("AWS_LOG_STREAM", "integration")
+
+	route := &router.Route{}
+	messages := make(chan *router.Message)
+
+	adapter, err := NewAdapter(route)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	go adapter.Stream(messages)
+	for i := 0; i < NumMessages; i++ {
+		messages <- &router.Message{Data: randomdata.Paragraph(), Time: time.Now()}
+	}
+
+	close(messages)
+}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,49 @@
+package cloudwatch
+
+import (
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+)
+
+type Log interface {
+	Body() string
+	Size() int
+	Timestamp() int64
+}
+
+// LogMessage represents a log message to be sent to CloudWatch.
+type LogMessage struct {
+	*router.Message
+}
+
+// Body returns a string representation of the log.
+func (l *LogMessage) Body() string {
+	return l.Data
+}
+
+// Size returns the size of the log message in bytes.
+func (l *LogMessage) Size() int {
+	return len(l.Data)
+}
+
+// Timestamp returns the number of milliseconds since the epoch.
+func (l *LogMessage) Timestamp() int64 {
+	return l.Time.UnixNano() / int64(time.Millisecond)
+}
+
+type FakeLog struct {
+	size int
+}
+
+func (l *FakeLog) Body() string {
+	return ""
+}
+
+func (l *FakeLog) Size() int {
+	return l.size
+}
+
+func (l *FakeLog) Timestamp() int64 {
+	return 0
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,39 @@
+package cloudwatch
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+	. "gopkg.in/check.v1"
+)
+
+func TestLog(t *testing.T) {
+	TestingT(t)
+}
+
+type LogSuite struct{}
+
+var _ = Suite(&LogSuite{})
+
+func (s *LogSuite) TestSize(c *C) {
+	var buffer bytes.Buffer
+
+	for i := 0; i < 2048; i++ {
+		buffer.WriteString("0")
+	}
+
+	msg := &router.Message{Data: buffer.String()}
+	log := LogMessage{msg}
+
+	c.Assert(log.Size(), Equals, 2048)
+}
+
+func (s *LogSuite) TestTimestamp(c *C) {
+	now := time.Now()
+	msg := &router.Message{Time: now}
+	log := LogMessage{msg}
+
+	c.Assert(log.Timestamp(), Equals, now.UnixNano()/int64(time.Millisecond))
+}

--- a/logstream.go
+++ b/logstream.go
@@ -1,0 +1,102 @@
+package cloudwatch
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+// LogStream ships logs to AWS CloudWatch.
+type LogStream struct {
+	group   *string
+	stream  *string
+	token   *string
+	service *cloudwatchlogs.CloudWatchLogs
+}
+
+// NewLogStream instantiates a Logger.
+func NewLogStream(group, stream string) (*LogStream, error) {
+	cloudwatch := cloudwatchlogs.New(nil)
+	logstream := &LogStream{
+		group:   aws.String(group),
+		stream:  aws.String(stream),
+		service: cloudwatch,
+	}
+
+	err := logstream.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return logstream, nil
+}
+
+// Init fetches the sequence token for a stream so logs can be streamed.
+func (s *LogStream) Init() error {
+	stream, err := s.findStream()
+	if err != nil {
+		return err
+	}
+
+	if stream != nil {
+		s.token = stream.UploadSequenceToken
+		return nil
+	}
+
+	return s.createStream()
+}
+
+func (s *LogStream) createStream() error {
+	params := &cloudwatchlogs.CreateLogStreamInput{
+		LogGroupName:  s.group,
+		LogStreamName: s.stream,
+	}
+
+	_, err := s.service.CreateLogStream(params)
+
+	return err
+}
+
+func (s *LogStream) findStream() (*cloudwatchlogs.LogStream, error) {
+	params := &cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName:        s.group,
+		LogStreamNamePrefix: s.stream,
+		Limit:               aws.Int64(1),
+	}
+
+	resp, err := s.service.DescribeLogStreams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.LogStreams) == 0 {
+		return nil, nil
+	}
+
+	return resp.LogStreams[0], nil
+}
+
+// Log submits a batch of logs to the LogStream.
+func (s *LogStream) Log(logs []*cloudwatchlogs.InputLogEvent) {
+	params := &cloudwatchlogs.PutLogEventsInput{
+		LogEvents:     logs,
+		LogGroupName:  s.group,
+		LogStreamName: s.stream,
+		SequenceToken: s.token,
+	}
+
+	resp, err := s.service.PutLogEvents(params)
+	if err != nil {
+		log.Printf("Log upload failed - length: %d, error: %v", len(logs), err)
+		return
+	}
+
+	if resp.RejectedLogEventsInfo != nil {
+		log.Printf("Log upload succeeded with rejected events - length: %d", len(logs))
+	} else {
+		log.Printf("Log upload succeeded - length: %d", len(logs))
+	}
+
+	s.token = resp.NextSequenceToken
+}

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,21 @@
+package cloudwatch
+
+import "github.com/gliderlabs/logspout/router"
+
+func transform(messages <-chan *router.Message) <-chan Log {
+	logs := make(chan Log)
+
+	go func() {
+		defer close(logs)
+
+		for msg := range messages {
+			logs <- transformMessage(msg)
+		}
+	}()
+
+	return logs
+}
+
+func transformMessage(msg *router.Message) Log {
+	return &LogMessage{msg}
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,0 +1,26 @@
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/gliderlabs/logspout/router"
+	. "gopkg.in/check.v1"
+)
+
+func TestTransform(t *testing.T) {
+	TestingT(t)
+}
+
+type TransformSuite struct{}
+
+var _ = Suite(&TransformSuite{})
+
+func (s *TransformSuite) TestTransformsMessageToLog(c *C) {
+	messages := make(chan *router.Message)
+	logs := transform(messages)
+
+	messages <- &router.Message{Data: "hello world"}
+	log := <-logs
+
+	c.Assert(log.Body(), Equals, "hello world")
+}


### PR DESCRIPTION
This PR implements a CloudWatch adapter for Logspout. The CloudWatch API imposes a [number of limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html) that the adapter must respect:
- Maximum event size of 256KB.
- Maximum batch size of 1MB.
- Maximum batch count of 10000 events.
- 5 PutLogEvents requests per second per log stream.

In order to respect these API limits, this module introduces an in-memory log buffer that flushes the buffer whenever batch limits are hit. Additionally, it flushes batches periodically even if the batch limit has not been reached. The flush interval is configured to prevent hitting the 5 req/s/stream rate limit.
