### PR TITLE
Gracefully handle InvalidSequenceTokenException.

### DIFF
--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -7,7 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/gliderlabs/logspout/router"
 )
@@ -46,10 +45,8 @@ func NewAdapter(route *router.Route) (router.LogAdapter, error) {
 	if err != nil {
 		return nil, err
 	}
-	
-	session := session.New()
-	logstream := NewLogStream(group, stream, session)
-	err = logstream.Init()
+
+	logstream, err := NewLogStream(group, stream)
 	if err != nil {
 		return nil, err
 	}

--- a/logstream.go
+++ b/logstream.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
@@ -18,15 +18,17 @@ type LogStream struct {
 }
 
 // NewLogStream instantiates a Logger.
-func NewLogStream(group, stream string, config client.ConfigProvider) *LogStream {
-	cloudwatch := cloudwatchlogs.New(config)
+func NewLogStream(group, stream string) (*LogStream, error) {
+	session := session.New()
+	cloudwatch := cloudwatchlogs.New(session)
 	logstream := &LogStream{
 		Group:   aws.String(group),
 		Stream:  aws.String(stream),
 		service: cloudwatch,
 	}
+	err := logstream.Init()
 
-	return logstream
+	return logstream, err
 }
 
 // Init fetches the sequence token for a stream so logs can be streamed.

--- a/logstream.go
+++ b/logstream.go
@@ -74,7 +74,7 @@ func (s *LogStream) findStream() (*cloudwatchlogs.LogStream, error) {
 }
 
 // Log submits a batch of logs to the LogStream.
-func (s *LogStream) Log(logs []*cloudwatchlogs.InputLogEvent) {
+func (s *LogStream) Log(logs []*cloudwatchlogs.InputLogEvent) error {
 	params := &cloudwatchlogs.PutLogEventsInput{
 		LogEvents:     logs,
 		LogGroupName:  s.Group,
@@ -85,7 +85,7 @@ func (s *LogStream) Log(logs []*cloudwatchlogs.InputLogEvent) {
 	resp, err := s.service.PutLogEvents(params)
 	if err != nil {
 		log.Errorf("Log upload failed - length: %d, error: %v", len(logs), err)
-		return
+		return err
 	}
 
 	if resp.RejectedLogEventsInfo != nil {
@@ -95,4 +95,6 @@ func (s *LogStream) Log(logs []*cloudwatchlogs.InputLogEvent) {
 	}
 
 	s.Token = resp.NextSequenceToken
+
+	return nil
 }

--- a/logstream_test.go
+++ b/logstream_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/bradgignac/logspout-cloudwatch/test"
 	. "gopkg.in/check.v1"
 )
+
+const REGION = "us-west-2"
 
 func TestLogStream(t *testing.T) {
 	TestingT(t)
@@ -18,6 +19,7 @@ func TestLogStream(t *testing.T) {
 type LogStreamSuite struct {
 	mock    *test.CloudWatchLogsMock
 	session *session.Session
+	stream  *LogStream
 }
 
 var _ = Suite(&LogStreamSuite{})
@@ -25,13 +27,13 @@ var _ = Suite(&LogStreamSuite{})
 func (s *LogStreamSuite) SetUpTest(c *C) {
 	s.mock = test.NewCloudWatchLogsMock()
 
-	creds := credentials.NewStaticCredentials("id", "secret", "token")
 	config := aws.NewConfig().
-		WithCredentials(creds).
 		WithEndpoint(s.mock.URL).
-		WithRegion("us-east-1").
+		WithRegion(REGION).
 		WithDisableSSL(true)
-	s.session = session.New(config)
+	session := session.New(config)
+
+	s.stream = NewLogStream("group", "stream", session)
 }
 
 func (s *LogStreamSuite) TearDownTest(c *C) {
@@ -39,24 +41,60 @@ func (s *LogStreamSuite) TearDownTest(c *C) {
 }
 
 func (s *LogStreamSuite) TestNewStream(c *C) {
-	stream := NewLogStream("group", "new", s.session)
-	err := stream.Init()
+	err := s.stream.Init()
+	streams := s.mock.GetStreams("group")
 
 	c.Assert(err, IsNil)
-	c.Assert(stream.Token, IsNil)
-	c.Assert(s.mock.Streams, HasLen, 1)
+	c.Assert(s.stream.Token, IsNil)
+	c.Assert(streams, HasLen, 1)
 }
 
 func (s *LogStreamSuite) TestExistingStream(c *C) {
-	s.mock.Streams = append(s.mock.Streams, &cloudwatchlogs.LogStream{
-		LogStreamName:       aws.String("existing"),
-		UploadSequenceToken: aws.String("existing"),
-	})
+	s.mock.AddStream("group", "stream")
 
-	stream := NewLogStream("group", "existing", s.session)
-	err := stream.Init()
+	err := s.stream.Init()
+	streams := s.mock.GetStreams("group")
 
 	c.Assert(err, IsNil)
-	c.Assert(stream.Token, NotNil)
-	c.Assert(s.mock.Streams, HasLen, 1)
+	c.Assert(s.stream.Token, NotNil)
+	c.Assert(streams, HasLen, 1)
+}
+
+func (s *LogStreamSuite) TestPutLogsToNewStream(c *C) {
+	s.mock.AddStream("group", "stream")
+
+	logs := []*cloudwatchlogs.InputLogEvent{
+		&cloudwatchlogs.InputLogEvent{
+			Message:   aws.String("body"),
+			Timestamp: aws.Int64(0),
+		},
+	}
+
+	err := s.stream.Log(logs)
+	stream := s.mock.GetStream("group", "stream")
+	token := aws.StringValue(s.stream.Token)
+
+	c.Assert(err, IsNil)
+	c.Assert(token, Equals, "1")
+	c.Assert(stream.LogCount, Equals, 1)
+}
+
+func (s *LogStreamSuite) TestPutLogsToExistingStream(c *C) {
+	s.mock.AddStream("group", "stream")
+
+	logs := []*cloudwatchlogs.InputLogEvent{
+		&cloudwatchlogs.InputLogEvent{
+			Message:   aws.String("body"),
+			Timestamp: aws.Int64(0),
+		},
+	}
+	s.stream.Log(logs)
+
+	err := s.stream.Log(logs)
+	stream := s.mock.GetStream("group", "stream")
+	token := aws.StringValue(s.stream.Token)
+
+	c.Assert(err, IsNil)
+	c.Assert(token, Equals, "2")
+	c.Assert(stream.LogCount, Equals, 2)
 }

--- a/logstream_test.go
+++ b/logstream_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/bradgignac/logspout-cloudwatch/test"
@@ -27,7 +28,9 @@ var _ = Suite(&LogStreamSuite{})
 func (s *LogStreamSuite) SetUpTest(c *C) {
 	s.mock = test.NewCloudWatchLogsMock()
 
+	creds := credentials.NewStaticCredentials("id", "secret", "token")
 	config := aws.NewConfig().
+		WithCredentials(creds).
 		WithEndpoint(s.mock.URL).
 		WithRegion(REGION).
 		WithDisableSSL(true)

--- a/logstream_test.go
+++ b/logstream_test.go
@@ -98,3 +98,24 @@ func (s *LogStreamSuite) TestPutLogsToExistingStream(c *C) {
 	c.Assert(token, Equals, "2")
 	c.Assert(stream.LogCount, Equals, 2)
 }
+
+func (s *LogStreamSuite) TestHandlesBadSequenceToken(c *C) {
+	s.mock.AddStream("group", "stream")
+	s.stream.Init()
+
+	stream := s.mock.GetStream("group", "stream")
+	stream.Token = 10
+
+	logs := []*cloudwatchlogs.InputLogEvent{
+		&cloudwatchlogs.InputLogEvent{
+			Message:   aws.String("body"),
+			Timestamp: aws.Int64(0),
+		},
+	}
+	err := s.stream.Log(logs)
+	token := aws.StringValue(s.stream.Token)
+
+	c.Assert(err, IsNil)
+	c.Assert(token, Equals, "11")
+	c.Assert(stream.LogCount, Equals, 1)
+}

--- a/logstream_test.go
+++ b/logstream_test.go
@@ -36,7 +36,11 @@ func (s *LogStreamSuite) SetUpTest(c *C) {
 		WithDisableSSL(true)
 	session := session.New(config)
 
-	s.stream = NewLogStream("group", "stream", session)
+	s.stream = &LogStream{
+		Group:   aws.String("group"),
+		Stream:  aws.String("stream"),
+		service: cloudwatchlogs.New(session),
+	}
 }
 
 func (s *LogStreamSuite) TearDownTest(c *C) {

--- a/test/cloudwatchlogs.go
+++ b/test/cloudwatchlogs.go
@@ -113,7 +113,18 @@ func (m *CloudWatchLogsMock) putLogEvents(w http.ResponseWriter, r *http.Request
 
 	group := aws.StringValue(data.LogGroupName)
 	stream := aws.StringValue(data.LogStreamName)
+	token := aws.StringValue(data.SequenceToken)
+
 	s := m.GetStream(group, stream)
+	if strconv.Itoa(s.Token) != token && s.Token != 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		m.writeJSON(w, &map[string]interface{}{
+			"__type":  "InvalidSequenceTokenException",
+			"message": "The given sequenceToken is invalid.",
+		})
+		return
+	}
+
 	s.LogCount += len(data.LogEvents)
 	s.Token++
 


### PR DESCRIPTION
When an `InvalidSequenceTokenException` is received, the logger should ask CloudWatch Logs for a new session token to use. Closes #12.
